### PR TITLE
[TASK] Remove switchableControllerActions from TypoScript

### DIFF
--- a/Configuration/TypoScript/Solr/setup.typoscript
+++ b/Configuration/TypoScript/Solr/setup.typoscript
@@ -396,31 +396,15 @@ plugin.tx_solr_PiResults_Results < lib.solr_extbase_bootstrap
 plugin.tx_solr_PiResults_Results = USER_INT
 plugin.tx_solr_PiResults_Results {
   pluginName = pi_results
-  switchableControllerActions {
-    Search {
-      1 = results
-      2 = form
-    }
-  }
 }
 
 plugin.tx_solr_PiSearch_Search < lib.solr_extbase_bootstrap
 plugin.tx_solr_PiSearch_Search {
   pluginName = pi_search
-  switchableControllerActions {
-    Search {
-      1 = form
-    }
-  }
 }
 
 plugin.tx_solr_PiFrequentSearches_FrequentSearches < lib.solr_extbase_bootstrap
 plugin.tx_solr_PiFrequentSearches_FrequentSearches {
   pluginName = pi_frequentlySearched
-  switchableControllerActions {
-    Search {
-      1 = frequentlySearched
-    }
-  }
 }
 


### PR DESCRIPTION
# What this pr does

`switchableControllerActions` have been removed in TYPO3 v12. Therefore, the usage in TypoScript have no effect and can safely be removed.

# How to test

Everything should work like before

Fixes: #4014
